### PR TITLE
C#7.3 Compatibility, .Net Standart 2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Stira.WpfCore"]
+	path = Stira.WpfCore
+	url = https://github.com/Touseefelahi/Stira.WpfCore.git

--- a/DeviceControl.Wpf/DeviceControl.Wpf.csproj
+++ b/DeviceControl.Wpf/DeviceControl.Wpf.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <AssemblyName>DeviceControl.Wpf</AssemblyName>
-    <TargetFrameworks>net5.0-windows;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <AvaloniaVersion>11.0.2</AvaloniaVersion>
   </PropertyGroup>
 </Project>

--- a/GenICam.Tests/GenICam.Tests.csproj
+++ b/GenICam.Tests/GenICam.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/GenICam.Tests/Helper.cs
+++ b/GenICam.Tests/Helper.cs
@@ -37,7 +37,7 @@ namespace GenICam.Tests
 
         [Theory]
         [InlineData("(8))")]
-        [InlineData("((8)")]
+        [InlineData("(8")]
         public void GetBracket(string formula)
         {
             var expected = "(8)";

--- a/GenICam/Exceptions/GenICamException.cs
+++ b/GenICam/Exceptions/GenICamException.cs
@@ -12,7 +12,7 @@ namespace GenICam
         /// </summary>
         /// <param name="message">error message</param>
         /// <param name="inner">inner exception that holds the original exception</param>
-        public GenICamException(string message, Exception? inner = null)
+        public GenICamException(string message, Exception inner = null)
             : base(message, inner)
         {
         }

--- a/GenICam/GenICam.csproj
+++ b/GenICam/GenICam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>x64</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>2.2</Version>

--- a/GenICam/Helpers/MathParserHelper.cs
+++ b/GenICam/Helpers/MathParserHelper.cs
@@ -11,7 +11,7 @@ namespace GenICam
     /// </summary>
     public class MathParserHelper
     {
-        private static readonly List<char> opreations = new() { '(', '+', '-', '/', '*', '=', '?', ':', ')', '>', '<', '&', '|', '^', '~', '%' };
+        private static readonly List<char> opreations = new List<char>() { '(', '+', '-', '/', '*', '=', '?', ':', ')', '>', '<', '&', '|', '^', '~', '%' };
 
         /// <summary>
         /// Prepare a formula.
@@ -46,17 +46,18 @@ namespace GenICam
         /// <returns>The result.</returns>
         public static double CalculateExpression(string experssion)
         {
+            //throw new NotImplementedException();
             try
             {
                 if (experssion.Contains("?"))
                 {
-                    var cases = experssion.Split(':', 2);
-                    var subs = cases[0].Split("?", 2);
+                    var cases = experssion.Split(new char[] { ':' }, 2);
+                    var subs = cases[0].Split(new char[] { '?' }, 2);
 
                     experssion = $"if({GetBracketed(subs[0])}, {GetBracketed(subs[1])}, {CalculateExpression(GetBracketed(cases[1]))})";
                 }
 
-                return new Expression(experssion).calculate();
+                return new Expression(GetBracketed(experssion)).calculate();
             }
             catch (Exception ex)
             {
@@ -96,7 +97,7 @@ namespace GenICam
 
             while (openBracketCounter > 0)
             {
-                formula = formula.Remove(0, 1);
+                formula += ")";
                 --openBracketCounter;
             }
 
@@ -149,7 +150,7 @@ namespace GenICam
             {
                 if (word.StartsWith("0x"))
                 {
-                    values.Push(long.Parse(word[2..], System.Globalization.NumberStyles.HexNumber));
+                    values.Push(long.Parse(word.Substring(2), System.Globalization.NumberStyles.HexNumber));
 
                     // valuesList.Last().Push(values.Peek());
                 }
@@ -622,7 +623,7 @@ namespace GenICam
             double result;
             string equation;
 
-            foreach (var item in formula.Split('(', StringSplitOptions.None))
+            foreach (var item in formula.Split('('))
             {
                 equation = item;
                 if (item.Contains(')'))

--- a/GenICam/Interfaces/Helpers/IPValue.cs
+++ b/GenICam/Interfaces/Helpers/IPValue.cs
@@ -11,13 +11,13 @@ namespace GenICam
         /// Gets the value async.
         /// </summary>
         /// <returns>The value as long.</returns>
-        public Task<long?> GetValueAsync();
+        Task<long?> GetValueAsync();
 
         /// <summary>
         /// Sets the value async.
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public Task<IReplyPacket> SetValueAsync(long value);
+        Task<IReplyPacket> SetValueAsync(long value);
     }
 }

--- a/GenICam/Interfaces/Helpers/IReplyPacket.cs
+++ b/GenICam/Interfaces/Helpers/IReplyPacket.cs
@@ -10,53 +10,53 @@ namespace GenICam
         /// <summary>
         /// Gets or sets error to display if any.
         /// </summary>
-        public string Error { get; set; }
+         string Error { get; set; }
 
         /// <summary>
         /// Gets or sets iP address of the sender.
         /// </summary>
-        public string IPSender { get; set; }
+         string IPSender { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether command sent.
         /// </summary>
-        public bool IsSent { get; set; }
+         bool IsSent { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether command Sent and camera replied.
         /// </summary>
-        public bool IsSentAndReplyReceived { get; set; }
+         bool IsSentAndReplyReceived { get; set; }
 
         /// <summary>
         /// Gets or sets sending Port.
         /// </summary>
-        public int PortSender { get; set; }
+         int PortSender { get; set; }
 
         /// <summary>
         /// Gets raw reply packet.
         /// </summary>
-        public List<byte> Reply { get; }
+         List<byte> Reply { get; }
 
         /// <summary>
         /// Gets or sets register value.
         /// </summary>
-        public uint RegisterValue { get; set; }
+         uint RegisterValue { get; set; }
 
         /// <summary>
         /// Gets or sets memory Value.
         /// </summary>
-        public byte[] MemoryValue { get; set; }
+         byte[] MemoryValue { get; set; }
 
         /// <summary>
         /// It sets the list of byte.
         /// </summary>
         /// <param name="reply">The reply bytes.</param>
-        public void SetReply(byte[] reply);
+         void SetReply(byte[] reply);
 
         /// <summary>
         /// It sets the list of byte.
         /// </summary>
         /// <param name="reply">The reply bytes.</param>
-        public void SetReply(List<byte> reply);
+         void SetReply(List<byte> reply);
     }
 }

--- a/GenICam/Interfaces/IBoolean.cs
+++ b/GenICam/Interfaces/IBoolean.cs
@@ -11,13 +11,13 @@ namespace GenICam
         /// Gets the value async.
         /// </summary>
         /// <returns>The value as boolean.</returns>
-        public Task<bool> GetValueAsync();
+         Task<bool> GetValueAsync();
 
         /// <summary>
         /// Sets the value async.
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public Task<IReplyPacket> SetValueAsync(bool value);
+         Task<IReplyPacket> SetValueAsync(bool value);
     }
 }

--- a/GenICam/Interfaces/ICategory.cs
+++ b/GenICam/Interfaces/ICategory.cs
@@ -10,16 +10,16 @@ namespace GenICam
         /// <summary>
         /// Gets the category properties.
         /// </summary>
-        public CategoryProperties CategoryProperties { get; }
+         CategoryProperties CategoryProperties { get; }
 
         /// <summary>
         /// Gets or sets the PFeatures.
         /// </summary>
-        public List<ICategory> PFeatures { get; set; }
+         List<ICategory> PFeatures { get; set; }
 
         /// <summary>
         /// Gets the PValue.
         /// </summary>
-        public IPValue PValue { get; }
+         IPValue PValue { get; }
     }
 }

--- a/GenICam/Interfaces/ICommand.cs
+++ b/GenICam/Interfaces/ICommand.cs
@@ -11,12 +11,12 @@ namespace GenICam
         /// Submits the command.
         /// </summary>
         /// <returns>A task.</returns>
-        public Task <IReplyPacket>Execute();
+         Task <IReplyPacket>Execute();
 
         /// <summary>
         /// Returns true if the command has been executed; false as long as it still  executes.
         /// </summary>
         /// <returns>True when it's finished.</returns>
-        public Task<bool> IsDone();
+         Task<bool> IsDone();
     }
 }

--- a/GenICam/Interfaces/IEnumeration.cs
+++ b/GenICam/Interfaces/IEnumeration.cs
@@ -13,20 +13,20 @@ namespace GenICam
         /// Gets the index value corresponding to the enumeration value.
         /// </summary>
         /// <returns>The index value as a long.</returns>
-        public Task<long> GetValueAsync();
+         Task<long> GetValueAsync();
 
         /// <summary>
         /// Sets the index value corresponding to the enumeration value.
         /// </summary>
         /// <param name="value">The index value to set.</param>
         /// <returns>A task.</returns>
-        public Task<IReplyPacket> SetValueAsync(long value);
+         Task<IReplyPacket> SetValueAsync(long value);
 
         /// <summary>
         /// Gets the entries of the enumeration.
         /// </summary>
         /// <returns>A dictionation with the enumeration values.</returns>
-        public Dictionary<string, EnumEntry> GetEntries();
+         Dictionary<string, EnumEntry> GetEntries();
 
         /// <summary>
         /// Returns a list of valid enumeration values.
@@ -42,7 +42,7 @@ namespace GenICam
         /// <param name="entryName">The entry name.</param>
         /// <returns>An enumeration entry.</returns>
         [Obsolete]
-        public EnumEntry GetEntryByName(string entryName);
+         EnumEntry GetEntryByName(string entryName);
 
         /// <summary>
         /// Gets the entry.
@@ -50,7 +50,7 @@ namespace GenICam
         /// <param name="entryValue">The entry index value.</param>
         /// <returns>An enumeration entry.</returns>
         [Obsolete]
-        public KeyValuePair<string, EnumEntry> GetEntry(long entryValue);
+         KeyValuePair<string, EnumEntry> GetEntry(long entryValue);
 
         /// <summary>
         /// Get the current entry.
@@ -58,6 +58,6 @@ namespace GenICam
         /// <param name="entryValue">The entry index value.</param>
         /// <returns>An enumeration entry.</returns>
         [Obsolete]
-        public KeyValuePair<string, EnumEntry> GetCurrentEntry();
+         KeyValuePair<string, EnumEntry> GetCurrentEntry();
     }
 }

--- a/GenICam/Interfaces/IFloat.cs
+++ b/GenICam/Interfaces/IFloat.cs
@@ -12,93 +12,93 @@ namespace GenICam
         /// Gets the value async.
         /// </summary>
         /// <returns>The value as a double.</returns>
-        public Task<double?> GetValueAsync();
+         Task<double?> GetValueAsync();
 
         /// <summary>
         /// Sets the value async.
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>A task.</returns>
-        public Task SetValueAsync(double value);
+         Task SetValueAsync(double value);
 
         /// <summary>
         /// Gets the minimum possible value async.
         /// </summary>
         /// <returns>The minimum possible value as a double.</returns>
-        public Task<double> GetMinAsync();
+         Task<double> GetMinAsync();
 
         /// <summary>
         /// Gets the maximum possible value async.
         /// </summary>
         /// <returns>The maximum possible value as a double.</returns>
-        public Task<double> GetMaxAsync();
+         Task<double> GetMaxAsync();
 
         /// <summary>
         /// Gets the increment mode.
         /// </summary>
         /// <returns>Te increment mode.</returns>
-        public IncrementMode GetIncrementMode();
+         IncrementMode GetIncrementMode();
 
         /// <summary>
         /// Gets the increment if GetIncrenmentMode returns fixedIncrement.
         /// </summary>
         /// <returns>The increment is specified.</returns>
-        public long? GetIncrement();
+         long? GetIncrement();
 
         /// <summary>
         /// Gets a list of valid values if GetIncrementMode returns listIncrement.
         /// </summary>
         /// <returns>the list of valid values.</returns>
-        public List<double>? GetListOfValidValue();
+         List<double> GetListOfValidValue();
 
         /// <summary>
         /// Gets the representation.
         /// </summary>
         /// <returns>The representation.</returns>
-        public Representation GetRepresentation();
+     Representation GetRepresentation();
 
         /// <summary>
         /// Gets the unit.
         /// </summary>
         /// <returns>A string represneting the unit.</returns>
-        public string GetUnit();
+         string GetUnit();
 
         /// <summary>
         /// Determines how to display the float number.
         /// </summary>
         /// <returns>The display notation for the float numbers.</returns>
-        public DisplayNotation GetDisplayNotation();
+         DisplayNotation GetDisplayNotation();
 
         /// <summary>
         /// Determines the precision to display the float number with.
         /// </summary>
         /// <returns>The display precision.</returns>
-        public long GetDisplayPrecision();
+         long GetDisplayPrecision();
 
         /// <summary>
         /// Gets a node with represents the same value in integer type.
         /// </summary>
         /// <returns>An interger node.</returns>
-        public IInteger GetIntAlias();
+         IInteger GetIntAlias();
 
         /// <summary>
         /// Gets a node with represents the same value in enumeration type.
         /// </summary>
         /// <returns>An enumeration node.</returns>
-        public IEnumeration GetEnumAlias();
+         IEnumeration GetEnumAlias();
 
         /// <summary>
         /// Imposes the minimum value async.
         /// </summary>
         /// <param name="min">The minimum value.</param>
         /// <returns>A task.</returns>
-        public Task ImposeMinAsync(long min);
+         Task ImposeMinAsync(long min);
 
         /// <summary>
         /// Imposes the maximum value async.
         /// </summary>
         /// <param name="max">The maximum value.</param>
         /// <returns>A task.</returns>
-        public Task ImposeMaxAsync(long max);
+         Task ImposeMaxAsync(long max);
     }
 }

--- a/GenICam/Interfaces/IInteger.cs
+++ b/GenICam/Interfaces/IInteger.cs
@@ -12,75 +12,75 @@ namespace GenICam
         /// Gets the value async.
         /// </summary>
         /// <returns>The value as a long.</returns>
-        public Task<long?> GetValueAsync();
+         Task<long?> GetValueAsync();
 
         /// <summary>
         /// Sets the value async.
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>A reply packet.</returns>
-        public Task<IReplyPacket> SetValueAsync(long value);
+         Task<IReplyPacket> SetValueAsync(long value);
 
         /// <summary>
         /// Gets the maximum value async.
         /// </summary>
         /// <returns>The maximum value as a long.</returns>
-        public Task<long> GetMaxAsync();
+         Task<long> GetMaxAsync();
 
         /// <summary>
         /// Gets the minimum value async.
         /// </summary>
         /// <returns>The minimum value as a long.</returns>
-        public Task<long> GetMinAsync();
+         Task<long> GetMinAsync();
 
         /// <summary>
         /// Gets the type of increment.
         /// </summary>
         /// <returns>The increment mode.</returns>
-        public IncrementMode GetIncrementMode();
+         IncrementMode GetIncrementMode();
 
         /// <summary>
         /// Gets the increment if GetIncrementMode returns fixedIncrement.
         /// </summary>
         /// <returns>The increment if available.</returns>
-        public long? GetIncrement();
+         long? GetIncrement();
 
         /// <summary>
         /// Returns a list of valid values if GetIncrementMode returns listIncrement.
         /// </summary>
         /// <returns>A list of values if available.</returns>
-        public List<long>? GetListOfValidValue();
+         List<long> GetListOfValidValue();
 
         /// <summary>
         /// Gets the representation.
         /// </summary>
         /// <returns>The representation.</returns>
-        public Representation GetRepresentation();
+         Representation GetRepresentation();
 
         /// <summary>
         /// Gets the unit.
         /// </summary>
         /// <returns>The unit.</returns>
-        public string GetUnit();
+         string GetUnit();
 
         /// <summary>
         /// Restricts the minimum.
         /// </summary>
         /// <param name="value">The value to impose.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public Task<IReplyPacket> ImposeMinAsync(long value);
+         Task<IReplyPacket> ImposeMinAsync(long value);
 
         /// <summary>
         /// Restricts the maximum.
         /// </summary>
         /// <param name="value">The value to impose.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public Task<IReplyPacket> ImposeMaxAsync(long value);
+         Task<IReplyPacket> ImposeMaxAsync(long value);
 
         /// <summary>
         /// Gets the node with represents the same value in float type.
         /// </summary>
         /// <returns>The float node.</returns>
-        public IFloat GetFloatAlias();
+         IFloat GetFloatAlias();
     }
 }

--- a/GenICam/Interfaces/IRegister.cs
+++ b/GenICam/Interfaces/IRegister.cs
@@ -14,29 +14,29 @@ namespace GenICam
         /// <param name="pBuffer">The bytes to write.</param>
         /// <param name="length">The lenght of bytes to write.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public Task<IReplyPacket> SetAsync(byte[] pBuffer, long length);
+         Task<IReplyPacket> SetAsync(byte[] pBuffer, long length);
 
         /// <summary>
         /// Gets the register bytes async.
         /// </summary>
         /// <returns>The register bytes.</returns>
-        public Task<byte[]> GetAsync();
+         Task<byte[]> GetAsync();
 
         /// <summary>
         /// Gets the register address as a long.
         /// </summary>
         /// <returns>The register address as a long.</returns>
-        public Task<long?> GetAddressAsync();
+         Task<long?> GetAddressAsync();
 
         /// <summary>
         /// Gets the register length.
         /// </summary>
         /// <returns>The length in byte.</returns>
-        public long GetLength();
+         long GetLength();
         /// <summary>
         /// Gets the access mode.
         /// </summary>
-        public GenAccessMode AccessMode { get; }
+         GenAccessMode AccessMode { get; }
 
     }
 }

--- a/GenICam/Interfaces/ISelector.cs
+++ b/GenICam/Interfaces/ISelector.cs
@@ -11,18 +11,18 @@ namespace GenICam
         /// Indicates if that node is a selector.
         /// </summary>
         /// <returns>True if it is a selector.</returns>
-        public Task<bool> IsSelectorAsync();
+         Task<bool> IsSelectorAsync();
 
         /// <summary>
         /// Returns a list of pointers to the feature nodes which are selected by the current node.
         /// </summary>
         /// <returns>The list of pointes on features.</returns>
-        public Task<IEnumeration> GetSelectedEntryAsync();
+         Task<IEnumeration> GetSelectedEntryAsync();
 
         /// <summary>
         ///  Returns a list of pointers to the feature nodes which are selecting the the current node.
         /// </summary>
         /// <returns>The list of pointers on the features.</returns>
-        public Task<IEnumeration> GetSelectingFeaturesAsync();
+         Task<IEnumeration> GetSelectingFeaturesAsync();
     }
 }

--- a/GenICam/Models/GenCategories/GenBoolean.cs
+++ b/GenICam/Models/GenCategories/GenBoolean.cs
@@ -34,7 +34,7 @@ namespace GenICam
         /// <returns>The value as a bool.</returns>
         public async Task<bool> GetValueAsync()
         {
-            if (PValue is not null)
+            if (!(PValue is null))
             {
                 var value = await PValue.GetValueAsync();
                 return value == 1;
@@ -50,7 +50,7 @@ namespace GenICam
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         public async Task<IReplyPacket> SetValueAsync(bool value)
         {
-            if (PValue is not null)
+            if (!(PValue is null))
             {
                 var valueInByte = Convert.ToByte(value);
                 return await PValue.SetValueAsync(valueInByte); ;

--- a/GenICam/Models/GenCategories/GenCommand.cs
+++ b/GenICam/Models/GenCategories/GenCommand.cs
@@ -45,7 +45,7 @@ namespace GenICam
         {
             try
             {
-                if (PValue is not null)
+                if (!(PValue is null))
                 {
                     return await PValue.SetValueAsync(CommandValue);
                 }

--- a/GenICam/Models/GenCategories/GenEnumeration.cs
+++ b/GenICam/Models/GenCategories/GenEnumeration.cs
@@ -42,7 +42,7 @@ namespace GenICam
         /// <inheritdoc/>
         public async Task<long> GetValueAsync()
         {
-            if (PValue is not null)
+            if (!(PValue is null))
             {
                 return (long)await PValue.GetValueAsync();
             }
@@ -53,7 +53,7 @@ namespace GenICam
         /// <inheritdoc/>
         public async Task<IReplyPacket> SetValueAsync(long value)
         {
-            if (PValue is not null)
+            if (!(PValue is null))
             {
                 try
                 {

--- a/GenICam/Models/GenCategories/GenFloat.cs
+++ b/GenICam/Models/GenCategories/GenFloat.cs
@@ -129,7 +129,7 @@ namespace GenICam
 
             if (IncMode != null)
             {
-                throw new GenICamException(message: $"Unable to get the increment value, Increment mode is {Enum.GetName((IncrementMode)IncMode)}", new InvalidOperationException());
+                throw new GenICamException(message: $"Unable to get the increment value, Increment mode is {Enum.GetName(typeof(IncrementMode), (IncrementMode)IncMode)}", new InvalidOperationException());
             }
 
             throw new GenICamException(message: $"Unable to get the increment value, Increment mode is missing", new NullReferenceException());
@@ -162,7 +162,7 @@ namespace GenICam
 
             if (IncMode != null)
             {
-                throw new GenICamException(message: $"Unable to get the valid values list, Increment mode is {Enum.GetName((IncrementMode)IncMode)}", new InvalidOperationException());
+                throw new GenICamException(message: $"Unable to get the valid values list, Increment mode is {Enum.GetName(typeof(IncrementMode), (IncrementMode)IncMode)}", new InvalidOperationException());
             }
 
             throw new GenICamException(message: $"Unable to get the increment value, Increment mode is missing", new NullReferenceException());
@@ -198,7 +198,7 @@ namespace GenICam
         /// <inheritdoc/>
         public async Task<long?> GetValueAsync()
         {
-            if (PValue is not null)
+            if (!(PValue is null))
             {
                     Value = (long)(await PValue.GetValueAsync());
                     return (long)Value;

--- a/GenICam/Models/GenCategories/GenInteger.cs
+++ b/GenICam/Models/GenCategories/GenInteger.cs
@@ -31,12 +31,12 @@ namespace GenICam
             PMax = pMax;
             PMin = pMin;
 
-            if (min is not null)
+            if (!(min is null))
             {
                 Min = (long)min;
             }
 
-            if (max is not null)
+            if (!(max is  null))
             {
                 if (max != 0)
                 {
@@ -44,12 +44,12 @@ namespace GenICam
                 }
             }
 
-            if (inc is not null)
+            if (!(inc is null))
             {
                 Inc = (long)inc;
             }
 
-            if (value is not null)
+            if (!(value is null))
             {
                 Value = (long)value;
             }
@@ -127,12 +127,12 @@ namespace GenICam
         /// <inheritdoc/>
         public async Task<long?> GetValueAsync()
         {
-            if (PValue is not null)
+            if (!(PValue is null))
             {
                 Value = (long)(await PValue.GetValueAsync());
                 return Value;
             }
-            else if (Value is not null)
+            else if (!(Value is null))
             {
                 return Value;
             }
@@ -146,7 +146,7 @@ namespace GenICam
             RaisePropertyChanged(nameof(Max));
             RaisePropertyChanged(nameof(Min));
 
-            if (PValue is not null)
+            if (!(PValue is null))
             {
                 return await PValue.SetValueAsync(value);
             }
@@ -160,7 +160,7 @@ namespace GenICam
         /// <returns>The minimum value or 0 if not set.</returns>
         public async Task<long> GetMinAsync()
         {
-            if (PMin is not null)
+            if (!(PMin is null))
             {
                 return (long)(await PMin.GetValueAsync());
             }
@@ -174,7 +174,7 @@ namespace GenICam
         /// <returns>The maximum value or 0 if not set.</returns>
         public async Task<long> GetMaxAsync()
         {
-            if (PMax is not null)
+            if (!(PMax is null))
             {
                 return (long)(await PMax.GetValueAsync());
             }
@@ -192,7 +192,7 @@ namespace GenICam
 
             if (IncMode != null)
             {
-                throw new GenICamException(message: $"Unable to get the increment value, Increment mode is {Enum.GetName((IncrementMode)IncMode)}", new InvalidOperationException());
+                throw new GenICamException(message: $"Unable to get the increment value, Increment mode is {Enum.GetName(typeof(IncrementMode), (IncrementMode)IncMode)}", new InvalidOperationException());
             }
 
             throw new GenICamException(message: $"Unable to get the increment value, Increment mode is missing", new NullReferenceException());
@@ -208,7 +208,7 @@ namespace GenICam
 
             if (IncMode != null)
             {
-                throw new GenICamException(message: $"Unable to get the valid values list, Increment mode is {Enum.GetName((IncrementMode)IncMode)}", new InvalidOperationException());
+                throw new GenICamException(message: $"Unable to get the valid values list, Increment mode is {Enum.GetName(typeof(IncrementMode), (IncrementMode)IncMode)}", new InvalidOperationException());
             }
 
             throw new GenICamException(message: $"Unable to get the increment value, Increment mode is missing", new NullReferenceException());

--- a/GenICam/Models/IMathematical.cs
+++ b/GenICam/Models/IMathematical.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// Gets the value.
         /// </summary>
-        public double Value { get; }
+        double Value { get; }
     }
 }

--- a/GenICam/Models/Registers/GenMaskedIntReg.cs
+++ b/GenICam/Models/Registers/GenMaskedIntReg.cs
@@ -150,13 +150,13 @@ namespace GenICam
                 switch (Length)
                 {
                     case 2:
-                        return BitConverter.ToUInt16(valueBytes);
+                        return BitConverter.ToUInt16(valueBytes, 0);
 
                     case 4:
-                        return BitConverter.ToUInt32(valueBytes);
+                        return BitConverter.ToUInt32(valueBytes, 0);
 
                     default:
-                        return BitConverter.ToInt64(valueBytes);
+                        return BitConverter.ToInt64(valueBytes, 0);
                 }
             }
             catch (ArgumentOutOfRangeException ex)

--- a/GenICam/Models/Registers/RegisterBase.cs
+++ b/GenICam/Models/Registers/RegisterBase.cs
@@ -72,7 +72,7 @@ namespace GenICam.Models
                     }
                 }
 
-                if (Address is not null)
+                if (!(Address is null))
                 {
                     return Address;
                 }

--- a/GenICam/Services/XmlHelper.cs
+++ b/GenICam/Services/XmlHelper.cs
@@ -154,7 +154,7 @@ namespace GenICam
         {
             try
             {
-                (IPValue pValue, IRegister register) tuple = new(null, null);
+                (IPValue pValue, IRegister register) tuple = (null, null);
                 if (GetAllNodesByAttirbuteValue(attirbuteValue: name) is XmlNodeList xmlNodeList)
                 {
                     ICategory category = null;
@@ -640,7 +640,7 @@ namespace GenICam
                     xmlNode = xmlNode.ParentNode;
                 }
 
-                if (!Enum.GetNames<RegisterType>().Where(x => x.Equals(xmlNode.Name) && x != "StructEntry").Any())
+                if (!Enum.GetNames(typeof(RegisterType)).Where(x => x.Equals(xmlNode.Name) && x != "StructEntry").Any())
                 {
                     throw new GenICamException(message: $"Failed to find GenRegister type by the given node name {xmlNode.Name}", new NotImplementedException());
                 }
@@ -697,7 +697,7 @@ namespace GenICam
                         Sign? sign = null;
                         if (signNode != null)
                         {
-                            sign = Enum.Parse<Sign>(signNode.InnerText);
+                            sign = (Sign)Enum.Parse(typeof(Sign), signNode.InnerText);
                         }
 
                         return new GenMaskedIntReg(genRegister.address, genRegister.length, msb, lsb, bit, sign, genRegister.accessMode, genRegister.pAddress, GenPort);
@@ -764,12 +764,12 @@ namespace GenICam
 
                             default:
                                 pAddress = await GetRegister(pNode);
-                                pAddress ??= await GetGenCategory(pNode);
+                                pAddress = (pAddress == null) ? await GetGenCategory(pNode) : pAddress;
 
                                 break;
                         }
 
-                        pAddress ??= await GetGenCategory(pNode);
+                        pAddress = (pAddress == null) ? await GetGenCategory(pNode) : pAddress;
                     }
                 }
 
@@ -876,11 +876,11 @@ namespace GenICam
 
                                     default:
                                         pVariable = await GetRegister(pNode);
-                                        pVariable ??= await GetGenCategory(pNode) as IPValue;
+                                        pVariable = (pVariable == null) ? await GetGenCategory(pNode) as IPValue : pVariable;
                                         break;
                                 }
 
-                                pVariable ??= await GetGenCategory(pNode) as IPValue;
+                                pVariable = (pVariable==null) ? await GetGenCategory(pNode) as IPValue : pVariable;
 
                                 pVariables.Add(node.Attributes[NodeName].Value, pVariable);
                             }
@@ -953,11 +953,11 @@ namespace GenICam
 
                                     default:
                                         pVariable = await GetRegister(pNode);
-                                        pVariable ??= await GetGenCategory(pNode) as IPValue;
+                                        pVariable = pVariable == null ? await GetGenCategory(pNode) as IPValue : pVariable;
                                         break;
                                 }
 
-                                pVariable ??= await GetGenCategory(pNode) as IPValue;
+                                pVariable = pVariable == null ? await GetGenCategory(pNode) as IPValue : pVariable;
 
                                 pVariables.Add(node.Attributes[NodeName].Value, pVariable);
                             }
@@ -977,15 +977,15 @@ namespace GenICam
                             if (pValueNode != null)
                             {
                                 pValue = await GetRegister(pValueNode);
-                                pValue ??= await GetIntSwissKnife(pValueNode);
-                                pValue ??= await GetConverter(pValueNode);
-                                pValue ??= await GetGenCategory(pValueNode) as IPValue;
+                                pValue = pValue == null ? await GetIntSwissKnife(pValueNode) : pValue;
+                                pValue = pValue == null ? await GetConverter(pValueNode) : pValue;
+                                pValue = pValue == null ? await GetGenCategory(pValueNode) as IPValue : pValue;
                             }
 
                             break;
 
                         case "Slope":
-                            slope = Enum.Parse<Slope>(node.InnerText);
+                            slope = (Slope)Enum.Parse(typeof(Slope), node.InnerText);
                             break;
 
                         default:
@@ -1029,7 +1029,7 @@ namespace GenICam
 
                 if (SelectSingleNode(xmlNode, "Visibility") is XmlNode visibilityNode)
                 {
-                    visibilty = Enum.Parse<GenVisibility>(visibilityNode.InnerText);
+                    visibilty = (GenVisibility)Enum.Parse(typeof(GenVisibility), visibilityNode.InnerText);
                 }
 
                 if (SelectSingleNode(xmlNode, "ToolTip") is XmlNode toolTipNode)

--- a/GigeVision.Core/GigeVision.Core.csproj
+++ b/GigeVision.Core/GigeVision.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Authors>Touseef Elahi</Authors>
     <Company>Stira.sa</Company>
     <Product>GigeVision</Product>
@@ -44,13 +44,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GenICam" Version="2.1.5.1" />
-    <PackageReference Include="Stira.WpfCore" Version="1.2.2" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\GenICam\GenICam.csproj" />
+    <ProjectReference Include="..\Stira.WpfCore\Stira.WpfCore\Stira.WpfCore.csproj" />
   </ItemGroup>
 
   <!--<ItemGroup>

--- a/GigeVision.Core/Services/GenPort.cs
+++ b/GigeVision.Core/Services/GenPort.cs
@@ -56,7 +56,7 @@ namespace GigeVision.Core
                 var addressBytes = GetAddressBytes((long)address, length);
                 Array.Reverse(addressBytes);
                 //await Gvcp.TakeControl(false);
-                return await Gvcp.WriteRegisterAsync(addressBytes, BitConverter.ToUInt32(pBuffer)).ConfigureAwait(false);
+                return await Gvcp.WriteRegisterAsync(addressBytes, BitConverter.ToUInt32(pBuffer, 0)).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/GigeVision.Core/Services/StreamReceiverBase.cs
+++ b/GigeVision.Core/Services/StreamReceiverBase.cs
@@ -103,7 +103,7 @@ namespace GigeVision.Core.Services
         protected void DetectGvspType()
         {
             Span<byte> singlePacket = new byte[9000];
-            socketRxRaw.Receive(singlePacket);
+            socketRxRaw.Receive(singlePacket.ToArray());
             GvspInfo.IsDecodingAsVersion2 = ((singlePacket[4] & 0xF0) >> 4) == 8;
             GvspInfo.SetDecodingTypeParameter();
 
@@ -120,7 +120,7 @@ namespace GigeVision.Core.Services
             }
 
             //Optimizing the array length for receive buffer
-            int length = socketRxRaw.Receive(singlePacket);
+            int length = socketRxRaw.Receive(singlePacket.ToArray());
             packetID = (singlePacket[GvspInfo.PacketIDIndex] << 8) | singlePacket[GvspInfo.PacketIDIndex + 1];
             if (packetID > 0)
             {
@@ -161,7 +161,7 @@ namespace GigeVision.Core.Services
 
                 while (IsReceiving)
                 {
-                    length = socketRxRaw.Receive(singlePacket);
+                    length = socketRxRaw.Receive(singlePacket.ToArray());
                     if (singlePacket[4] == GvspInfo.DataIdentifier) //Packet
                     {
                         packetRxCount++;
@@ -182,7 +182,7 @@ namespace GigeVision.Core.Services
                         blockID = singlePacket.Slice(GvspInfo.BlockIDIndex, GvspInfo.BlockIDLength).ToArray();
                         Array.Reverse(blockID);
                         Array.Resize(ref blockID, 8);
-                        imageID = BitConverter.ToUInt64(blockID);
+                        imageID = BitConverter.ToUInt64(blockID, 0);
                         packetRxCountClone = packetRxCount;
                         lastImageIDClone = lastImageID;
                         bufferIndexClone = bufferIndex;

--- a/GigeVision.Core/Services/StreamReceiverParallel.cs
+++ b/GigeVision.Core/Services/StreamReceiverParallel.cs
@@ -63,7 +63,7 @@ namespace GigeVision.Core.Services
                     singlePacket = memory[indexMemoryWriter].Slice(counterBufferWriter * GvspInfo.PacketLength, GvspInfo.PacketLength);
                     counterBufferWriter++;
 
-                    length = socketRxRaw.Receive(singlePacket.Span);
+                    length = socketRxRaw.Receive(singlePacket.Span.ToArray());
 
                     if (++counterForChunkPackets % ChunkPacketCount == 0)
                     {

--- a/GigeVision.Core/Services/StreamReceiverParallel_Legacy.cs
+++ b/GigeVision.Core/Services/StreamReceiverParallel_Legacy.cs
@@ -123,7 +123,7 @@ namespace GigeVision.Core.Services
             {
                 while (IsReceiving)
                 {
-                    int length = socketRxRaw.Receive(memoryList.Span.Slice(offset + localByteCounter, size));
+                    int length = socketRxRaw.Receive(memoryList.Span.Slice(offset + localByteCounter, size).ToArray());
                     timeSpansReception.Add(stopwatch.Elapsed);
                     if (length > 100)
                     {

--- a/GigeVision.Core/Services/StreamReceiverPipeLine.cs
+++ b/GigeVision.Core/Services/StreamReceiverPipeLine.cs
@@ -30,7 +30,7 @@ namespace GigeVision.Core.Services
         private async Task DecoderPipe(PipeReader reader)
         {
             int i;
-            byte[] buffer = GC.AllocateArray<byte>(length: GvspInfo.RawImageSize, pinned: true);
+            byte[] buffer = new byte[GvspInfo.RawImageSize]; //GC.AllocateArray<byte>(length: GvspInfo.RawImageSize, pinned: true);
             int bufferIndex = 0;
             int packetID = 0, bufferStart;
             int packetRxCount = 0;
@@ -45,10 +45,10 @@ namespace GigeVision.Core.Services
                 for (i = 0; i < dataBuffer.Buffer.Length - packetSize; i += packetSize)
                 {
                     var singlePacket = dataBuffer.Buffer.Slice(i, packetSize);
-                    if (singlePacket.FirstSpan.Slice(4, 1)[0] == GvspInfo.DataIdentifier) //Packet
+                    if (singlePacket.First.Span.Slice(4, 1)[0] == GvspInfo.DataIdentifier) //Packet
                     {
                         packetRxCount++;
-                        packetID = (singlePacket.FirstSpan.Slice(GvspInfo.PacketIDIndex, 1)[0] << 8) | singlePacket.FirstSpan.Slice(GvspInfo.PacketIDIndex + 1, 1)[0];
+                        packetID = (singlePacket.First.Span.Slice(GvspInfo.PacketIDIndex, 1)[0] << 8) | singlePacket.First.Span.Slice(GvspInfo.PacketIDIndex + 1, 1)[0];
                         bufferStart = (packetID - 1) * GvspInfo.PayloadSize; //This use buffer length of regular packet
                         listOfPacketIDs.Add(packetID);
                         //singlePacket.Slice(GvspInfo.PayloadOffset, GvspInfo.PayloadSize).CopyTo(buffer.AsSpan().Slice(bufferStart, GvspInfo.PayloadSize));
@@ -75,7 +75,7 @@ namespace GigeVision.Core.Services
             while (IsReceiving)
             {
                 var spanPacket = writer.GetMemory(9000);
-                int length = socketRxRaw.Receive(spanPacket.Span);
+                int length = socketRxRaw.Receive(spanPacket.Span.ToArray());
                 timeSpansReception.Add(stopwatch.Elapsed);
                 //int length = await socketRxRaw.ReceiveAsync(spanPacket, SocketFlags.None);
                 if (length > 100)

--- a/GigeVision.CoreTests/GigeVision.CoreTests.csproj
+++ b/GigeVision.CoreTests/GigeVision.CoreTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>.NETCoreApp,Version=v5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/GigeVision.CoreTests/Models/ConverterTests.cs
+++ b/GigeVision.CoreTests/Models/ConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/GigeVision.CoreTests/Models/GvcpCommandTests.cs
+++ b/GigeVision.CoreTests/Models/GvcpCommandTests.cs
@@ -15,7 +15,7 @@ namespace GigeVision.Core.Models.Tests
         [TestMethod()]
         public void GenerateCommandTest()
         {
-            GvcpCommand gvcpCommand = new GvcpCommand(Converter.RegisterStringToByteArray(GvcpRegister.CCP.ToString("X")), GvcpCommandType.ReadReg);
+            GvcpCommand gvcpCommand = new GvcpCommand(Converter.RegisterStringToByteArray(GvcpRegister.GevCCP.ToString("X")), GvcpCommandType.ReadReg);
         }
 
         [TestMethod()]

--- a/GigeVision.CoreTests/Models/GvcpTests.cs
+++ b/GigeVision.CoreTests/Models/GvcpTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using GigeVision.Core.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -16,6 +18,7 @@ namespace GigeVision.Core.Models.Tests
             gvcp = new Gvcp() { CameraIp = "192.168.10.155" };
         }
 
+        /*
         [TestMethod()]
         public async Task ReadAllRegisterAddressFromCameraAsyncTestAsync()
         {
@@ -30,18 +33,18 @@ namespace GigeVision.Core.Models.Tests
                 string startRegister = registers["AcquisitionStart"].Register.Address;
                 Assert.IsTrue(isTrue);
             }
-        }
+        }*/
 
         [TestMethod()]
         public async Task ReadRegisterAsyncTest()
         {
-            GvcpReply value = await gvcp.ReadRegisterAsync(ipCamera, Enums.GvcpRegister.CCP);
+            GvcpReply value = await gvcp.ReadRegisterAsync(ipCamera, Enums.GvcpRegister.GevCCP);
             if (value.IsSentAndReplyReceived)
             {
                 Assert.IsTrue(value.IsValid);
             }
 
-            GvcpReply value2 = await gvcp.ReadRegisterAsync(Enums.GvcpRegister.CCP);
+            GvcpReply value2 = await gvcp.ReadRegisterAsync(Enums.GvcpRegister.GevCCP);
             if (value2.IsSentAndReplyReceived)
             {
                 Assert.IsTrue(value2.IsValid);
@@ -68,7 +71,7 @@ namespace GigeVision.Core.Models.Tests
         public async Task WriteRegisterAsyncTest()
         {
             // var registers = await gvcp.ReadAllRegisterAddressFromCameraAsync().ConfigureAwait(false);
-            GvcpReply reply = await gvcp.WriteRegisterAsync(Enums.GvcpRegister.CCP, 2).ConfigureAwait(false);
+            GvcpReply reply = await gvcp.WriteRegisterAsync(Enums.GvcpRegister.GevCCP, 2).ConfigureAwait(false);
             // var repply = await gvcp.WriteRegisterAsync(ipCamera, Enums.GvcpRegister.SCDA, 1);
             await Task.Delay(1000);
             //var reply = await gvcp.WriteRegisterAsync(registers["AcquisitionStartReg"], 1);

--- a/GigeVision.OpenCV/GigeVision.OpenCV.csproj
+++ b/GigeVision.OpenCV/GigeVision.OpenCV.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Description>
-		GigE Vision Implementation With OpenCV/EMGU support
+		GigE Vision Implementation Using OpenCV
 	</Description>
 	<Version>1.0</Version>
     <Title>GigeVisionLibraryOpenCV</Title>
@@ -19,6 +18,10 @@
   <ItemGroup>
     <PackageReference Include="Emgu.CV" Version="4.9.0.5494" />
     <PackageReference Include="GigeVision.Core" Version="2.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GigeVision.Core\GigeVision.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/GigeVision.OpenCV/StreamReceiverParallelOpenCV.cs
+++ b/GigeVision.OpenCV/StreamReceiverParallelOpenCV.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GigeVision.OpenCV
@@ -12,14 +13,14 @@ namespace GigeVision.OpenCV
     public class StreamReceiverParallelOpencv : StreamReceiverBase
     {
         public uint frameInCounter = 0;
-        public Mat[] image = null!;
+        public Mat[] image = null;
         public long imageIndex, lossCount = 0;
-        public SemaphoreSlim waitHandleFrame = new(0);
+        public SemaphoreSlim waitHandleFrame = new SemaphoreSlim(0);
         private const int ChunkPacketCount = 100;
         private const int flatBufferCount = 5;
         private readonly int packetBufferLength = ChunkPacketCount;
-        private readonly SemaphoreSlim waitForPacketChunk = new(0);
-        private byte[][] packetBuffersFlat = null!;
+        private readonly SemaphoreSlim waitForPacketChunk = new SemaphoreSlim(0);
+        private byte[][] packetBuffersFlat = null;
 
         public StreamReceiverParallelOpencv(int totalBuffers = 3)
         {
@@ -70,7 +71,7 @@ namespace GigeVision.OpenCV
                     singlePacket = memory[indexMemoryWriter].Slice(counterBufferWriter * GvspInfo.PacketLength, GvspInfo.PacketLength);
                     counterBufferWriter++;
 
-                    length = socketRxRaw.Receive(singlePacket.Span);
+                    length = socketRxRaw.Receive(singlePacket.Span.ToArray());
 
                     if (++counterForChunkPackets % ChunkPacketCount == 0)
                     {

--- a/GigeVisionLibrary.Test.Console/GigeVisionLibrary.Test.Console.csproj
+++ b/GigeVisionLibrary.Test.Console/GigeVisionLibrary.Test.Console.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GigeVisionLibrary.Test.Console/Program.cs
+++ b/GigeVisionLibrary.Test.Console/Program.cs
@@ -1,4 +1,6 @@
 ﻿using GigeVision.Core.Services;
+using System;
+using System.Threading;
 
 namespace GigeVisionLibrary.Test.Con
 {

--- a/GigeVisionNoWpf.sln
+++ b/GigeVisionNoWpf.sln
@@ -1,0 +1,182 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32510.428
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GigeVision.Core", "GigeVision.Core\GigeVision.Core.csproj", "{9B36820D-781A-47FA-AEDB-20AC7433225D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{0307491D-B8FC-42AE-8EAB-69D2C072973B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Library", "Library", "{B120F0DB-D7D6-4ABA-845B-32117EB4B1B2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenICam", "GenICam\GenICam.csproj", "{329D0921-AC4C-430D-92CD-B387AE869764}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenICam.Tests", "GenICam.Tests\GenICam.Tests.csproj", "{76194E2F-D17E-42F6-8EF0-E084C408A022}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{5804CC7A-04CB-4BB5-A23B-C8A59D9B1638}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GigeVisionLibrary.Test.Console", "GigeVisionLibrary.Test.Console\GigeVisionLibrary.Test.Console.csproj", "{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GigeVision.OpenCV", "GigeVision.OpenCV\GigeVision.OpenCV.csproj", "{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stira.WpfCore", "Stira.WpfCore\Stira.WpfCore\Stira.WpfCore.csproj", "{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GigeVision.CoreTests", "GigeVision.CoreTests\GigeVision.CoreTests.csproj", "{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		PublishLocally|Any CPU = PublishLocally|Any CPU
+		PublishLocally|x64 = PublishLocally|x64
+		PublishLocally|x86 = PublishLocally|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Debug|Any CPU.Build.0 = Debug|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Debug|x64.ActiveCfg = Debug|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Debug|x64.Build.0 = Debug|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Debug|x86.Build.0 = Debug|Any CPU
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.PublishLocally|Any CPU.ActiveCfg = PublishLocally|Any CPU
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.PublishLocally|Any CPU.Build.0 = PublishLocally|Any CPU
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.PublishLocally|x64.ActiveCfg = PublishLocally|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.PublishLocally|x64.Build.0 = PublishLocally|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.PublishLocally|x86.ActiveCfg = PublishLocally|x86
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.PublishLocally|x86.Build.0 = PublishLocally|x86
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Release|x64.ActiveCfg = Release|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Release|x64.Build.0 = Release|x64
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Release|x86.ActiveCfg = Release|x86
+		{9B36820D-781A-47FA-AEDB-20AC7433225D}.Release|x86.Build.0 = Release|x86
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Debug|Any CPU.Build.0 = Debug|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Debug|x64.ActiveCfg = Debug|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Debug|x64.Build.0 = Debug|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Debug|x86.Build.0 = Debug|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.PublishLocally|Any CPU.ActiveCfg = Release|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.PublishLocally|Any CPU.Build.0 = Release|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.PublishLocally|x64.ActiveCfg = Release|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.PublishLocally|x64.Build.0 = Release|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.PublishLocally|x86.ActiveCfg = Release|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.PublishLocally|x86.Build.0 = Release|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Release|Any CPU.Build.0 = Release|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Release|x64.ActiveCfg = Release|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Release|x64.Build.0 = Release|x64
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Release|x86.ActiveCfg = Release|Any CPU
+		{329D0921-AC4C-430D-92CD-B387AE869764}.Release|x86.Build.0 = Release|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Debug|Any CPU.Build.0 = Debug|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Debug|x64.ActiveCfg = Debug|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Debug|x64.Build.0 = Debug|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Debug|x86.Build.0 = Debug|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.PublishLocally|Any CPU.ActiveCfg = Debug|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.PublishLocally|Any CPU.Build.0 = Debug|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.PublishLocally|x64.ActiveCfg = Debug|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.PublishLocally|x64.Build.0 = Debug|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.PublishLocally|x86.ActiveCfg = Debug|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.PublishLocally|x86.Build.0 = Debug|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Release|x64.ActiveCfg = Release|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Release|x64.Build.0 = Release|x64
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Release|x86.ActiveCfg = Release|Any CPU
+		{76194E2F-D17E-42F6-8EF0-E084C408A022}.Release|x86.Build.0 = Release|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Debug|x64.Build.0 = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Debug|x86.Build.0 = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.PublishLocally|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.PublishLocally|Any CPU.Build.0 = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.PublishLocally|x64.ActiveCfg = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.PublishLocally|x64.Build.0 = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.PublishLocally|x86.ActiveCfg = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.PublishLocally|x86.Build.0 = Debug|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Release|x64.ActiveCfg = Release|x64
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Release|x64.Build.0 = Release|x64
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Release|x86.ActiveCfg = Release|Any CPU
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A}.Release|x86.Build.0 = Release|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Debug|x64.Build.0 = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Debug|x86.Build.0 = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.PublishLocally|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.PublishLocally|Any CPU.Build.0 = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.PublishLocally|x64.ActiveCfg = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.PublishLocally|x64.Build.0 = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.PublishLocally|x86.ActiveCfg = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.PublishLocally|x86.Build.0 = Debug|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Release|x64.ActiveCfg = Release|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Release|x64.Build.0 = Release|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Release|x86.ActiveCfg = Release|Any CPU
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5}.Release|x86.Build.0 = Release|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Debug|x64.Build.0 = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Debug|x86.Build.0 = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.PublishLocally|Any CPU.ActiveCfg = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.PublishLocally|Any CPU.Build.0 = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.PublishLocally|x64.ActiveCfg = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.PublishLocally|x64.Build.0 = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.PublishLocally|x86.ActiveCfg = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.PublishLocally|x86.Build.0 = Debug|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Release|x64.ActiveCfg = Release|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Release|x64.Build.0 = Release|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Release|x86.ActiveCfg = Release|Any CPU
+		{3394FBFC-6590-43BD-89D4-B1A4F046CC2E}.Release|x86.Build.0 = Release|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.PublishLocally|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.PublishLocally|Any CPU.Build.0 = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.PublishLocally|x64.ActiveCfg = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.PublishLocally|x64.Build.0 = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.PublishLocally|x86.ActiveCfg = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.PublishLocally|x86.Build.0 = Debug|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Release|x64.Build.0 = Release|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2FE07A33-31F8-466F-A6A5-7C115AE17E2B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9B36820D-781A-47FA-AEDB-20AC7433225D} = {B120F0DB-D7D6-4ABA-845B-32117EB4B1B2}
+		{329D0921-AC4C-430D-92CD-B387AE869764} = {B120F0DB-D7D6-4ABA-845B-32117EB4B1B2}
+		{76194E2F-D17E-42F6-8EF0-E084C408A022} = {0307491D-B8FC-42AE-8EAB-69D2C072973B}
+		{9D658ABE-E015-4F3F-87F8-F290B12A2E1A} = {0307491D-B8FC-42AE-8EAB-69D2C072973B}
+		{4BAAC2B1-4449-4BCA-981B-A97E6FEEDFB5} = {B120F0DB-D7D6-4ABA-845B-32117EB4B1B2}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C6692468-3D71-4CF6-BBB2-3E938FFB2E6F}
+	EndGlobalSection
+EndGlobal

--- a/Stira.WpfCore/Stira.WpfCore.sln
+++ b/Stira.WpfCore/Stira.WpfCore.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.181
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stira.WpfCore", "Stira.WpfCore\Stira.WpfCore.csproj", "{955B711A-C87C-4A5A-A76E-4898CF0DD024}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{955B711A-C87C-4A5A-A76E-4898CF0DD024}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{955B711A-C87C-4A5A-A76E-4898CF0DD024}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{955B711A-C87C-4A5A-A76E-4898CF0DD024}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{955B711A-C87C-4A5A-A76E-4898CF0DD024}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {343DAD5F-AD2B-4817-AA62-40C19E8189CA}
+	EndGlobalSection
+EndGlobal

--- a/Stira.WpfCore/Stira.WpfCore/BaseNotifyPropertyChanged.cs
+++ b/Stira.WpfCore/Stira.WpfCore/BaseNotifyPropertyChanged.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+
+namespace Stira.WpfCore
+{
+    public abstract class BaseNotifyPropertyChanged : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// The event that is fired when any child property changes its value
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged = (sender, e) => { };
+
+        #region Public Methods
+
+        /// <summary> Call this to fire a <see cref=”PropertyChanged”/> event </summary> <param name=”name”></param>
+        public void OnPropertyChanged(string name)
+        {
+            PropertyChangedEventHandler handler = PropertyChanged;
+            handler?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/Stira.WpfCore/Stira.WpfCore/DelegateCommand.cs
+++ b/Stira.WpfCore/Stira.WpfCore/DelegateCommand.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Stira.WpfCore
+{
+    public class DelegateCommand : ICommand
+    {
+        #region Private Members
+
+        /// <summary>
+        /// The action to run
+        /// </summary>
+        private readonly Action mAction;
+
+        #endregion Private Members
+
+        #region Public Events
+
+        /// <summary>
+        /// The event thats fired when the <see cref="CanExecute(object)"/> value has changed
+        /// </summary>
+        public event EventHandler CanExecuteChanged = (sender, e) => { };
+
+        #endregion Public Events
+
+        #region Constructor
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public DelegateCommand(Action action)
+        {
+            mAction = action;
+        }
+
+        #endregion Constructor
+
+        #region Command Methods
+
+        /// <summary>
+        /// A relay command can always execute
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <returns></returns>
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Executes the commands Action
+        /// </summary>
+        /// <param name="parameter"></param>
+        public void Execute(object parameter)
+        {
+            mAction();
+        }
+
+        #endregion Command Methods
+    }
+}

--- a/Stira.WpfCore/Stira.WpfCore/Stira.WpfCore.csproj
+++ b/Stira.WpfCore/Stira.WpfCore/Stira.WpfCore.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <Authors>Touseef Elahi</Authors>
+    <Company>Stira.sa</Company>
+    <Product>WPF Core</Product>
+    <Description>Simple implementation of ICommand Interface and INotifyPropertyChanged
+Inspired by AngelSix (Luke) youtube channel
+</Description>
+    <PackageTags>Wpf, Propertychanged, DelegateCommand</PackageTags>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This is definetly not ready to be merged. 

Target Frameworks have to be Edited and I'm not sure whether you really want to give up on the syntactic shugar of C#9.0. 

Also all methods taking `byte[]` as an argument don't accept  ` Span<byte>` in C#7.3 so I just lazily inserted `ToArray()` everywhere, not sure what this does under the hood but it could lead to serous performance issues.

But I thought this may be useful for someone anyway. :)