### PR TITLE
Socket receive timeout should be configurable

### DIFF
--- a/GigeVision.Core/Interfaces/IGvcp.cs
+++ b/GigeVision.Core/Interfaces/IGvcp.cs
@@ -27,6 +27,11 @@ namespace GigeVision.Core.Interfaces
         /// Camera IP
         /// </summary>
         string CameraIp { get; set; }
+        
+        /// <summary>
+        /// The socket read timeout in milliseconds. Set -1 for infinite timeout
+        /// </summary>
+        int ReceiveTimeoutInMilliseconds { get; set; }
 
         /// <summary>
         /// Controlling port for GVCP

--- a/GigeVision.Core/Interfaces/IStreamReceiver.cs
+++ b/GigeVision.Core/Interfaces/IStreamReceiver.cs
@@ -47,6 +47,11 @@ namespace GigeVision.Core.Interfaces
         /// RX IP, required for multicast group
         /// </summary>
         string RxIP { get; set; }
+        
+        /// <summary>
+        /// The socket receive timeout in milliseconds. Set -1 to infinite timeout
+        /// </summary>
+        public int ReceiveTimeoutInMilliseconds { get; set; }
 
         /// <summary>
         /// General update event

--- a/GigeVision.Core/Services/Camera.cs
+++ b/GigeVision.Core/Services/Camera.cs
@@ -100,6 +100,22 @@ namespace GigeVision.Core.Services
         }
 
         /// <summary>
+        /// The receive socket timeout in milliseconds. Set -1 for infinite timeout
+        /// </summary>
+        public int ReceiveTimeoutInMilliseconds
+        {
+            get => Gvcp.ReceiveTimeoutInMilliseconds;
+            set
+            {
+                Gvcp.ReceiveTimeoutInMilliseconds = value;
+                StreamReceiver.ReceiveTimeoutInMilliseconds = value;
+                
+                OnPropertyChanged(nameof(ReceiveTimeoutInMilliseconds));
+            }
+        }
+
+        
+        /// <summary>
         /// Multi-Cast Option
         /// </summary>
         public bool IsMulticast
@@ -625,6 +641,7 @@ namespace GigeVision.Core.Services
         {
             StreamReceiver ??= new StreamReceiverBufferswap();
             StreamReceiver.RxIP = RxIP;
+            StreamReceiver.ReceiveTimeoutInMilliseconds = ReceiveTimeoutInMilliseconds;
             StreamReceiver.IsMulticast = IsMulticast;
             StreamReceiver.MulticastIP = MulticastIP;
             StreamReceiver.PortRx = PortRx;

--- a/GigeVision.Core/Services/Gvcp.cs
+++ b/GigeVision.Core/Services/Gvcp.cs
@@ -39,13 +39,30 @@ namespace GigeVision.Core.Services
         {
             CameraIp = ip;
         }
+        
+        /// <summary>
+        /// Gvcp constructor, initializes camera IP and socket timeout, and try to get register values
+        /// </summary>
+        /// <param name="ip"></param>
+        /// <param name="socketReadTimeoutInMilliseconds"></param>
+        public Gvcp(string ip, int socketReadTimeoutInMilliseconds)
+        {
+            CameraIp = ip;
+            ReceiveTimeoutInMilliseconds = socketReadTimeoutInMilliseconds;
+        }
 
         /// <summary>
         /// Default GVCP constructor
         /// </summary>
         public Gvcp()
         {
+            ReceiveTimeoutInMilliseconds = 1000;
         }
+        
+        /// <summary>
+        /// The socket read timeout in milliseconds. Set -1 for infinite timeout
+        /// </summary>
+        public int ReceiveTimeoutInMilliseconds { get; set; }
 
         /// <summary>
         /// Camera IP, whenever changed, library tries to get latest register values
@@ -315,7 +332,7 @@ namespace GigeVision.Core.Services
             {
                 GvcpCommand command = new(memoryAddress, GvcpCommandType.ReadMem, requestID: gvcpRequestID++, count: count);
                 using UdpClient socket = new();
-                socket.Client.ReceiveTimeout = 1000;
+                socket.Client.ReceiveTimeout = ReceiveTimeoutInMilliseconds;
                 socket.Connect(ip, 3956);
                 return await SendGvcpCommand(socket, command).ConfigureAwait(false);
             }

--- a/GigeVision.Core/Services/StreamReceiverBase.cs
+++ b/GigeVision.Core/Services/StreamReceiverBase.cs
@@ -24,7 +24,13 @@ namespace GigeVision.Core.Services
         {
             GvspInfo = new GvspInfo();
             MissingPacketTolerance = 2;
+            ReceiveTimeoutInMilliseconds = 1000;
         }
+        
+        /// <summary>
+        /// The socket receive timeout in milliseconds. Set -1 to infinite timeout
+        /// </summary>
+        public int ReceiveTimeoutInMilliseconds { get; set; }
 
         /// <summary>
         /// Event for frame ready
@@ -242,7 +248,7 @@ namespace GigeVision.Core.Services
                     MulticastOption mcastOption = new(IPAddress.Parse(MulticastIP), IPAddress.Parse(RxIP));
                     socketRxRaw.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, mcastOption);
                 }
-                socketRxRaw.ReceiveTimeout = 1000;
+                socketRxRaw.ReceiveTimeout = ReceiveTimeoutInMilliseconds;
                 //One full hd image with GVSP2.0 Header as default, it will be updated for image type
                 socketRxRaw.ReceiveBufferSize = (int)(1920 * 1100);
             }


### PR DESCRIPTION
In some circumstances the hard-coded socket receive timeout set to 1000ms is not enough. The timeout of reception should be configurable. The default has been kept to 1000ms as per backward compatibility.