### PR TITLE
Remove direct STIRA.WPF dependency keeping the possibility to use it

### DIFF
--- a/GigeVision.Core/BaseNotifyPropertyChanged/BaseNotifyPropertyChanged.cs
+++ b/GigeVision.Core/BaseNotifyPropertyChanged/BaseNotifyPropertyChanged.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+
+namespace GigeVision.Core
+{
+    public abstract class BaseNotifyPropertyChanged : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// The event that is fired when any child property changes its value
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged = (sender, e) => { };
+
+        #region Public Methods
+
+        /// <summary> Call this to fire a <see cref=”PropertyChanged”/> event </summary> <param name=”name”></param>
+        public void OnPropertyChanged(string name)
+        {
+            PropertyChangedEventHandler handler = PropertyChanged;
+            handler?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/GigeVision.Core/BaseNotifyPropertyChanged/BaseNotifyPropertyChanged.cs
+++ b/GigeVision.Core/BaseNotifyPropertyChanged/BaseNotifyPropertyChanged.cs
@@ -7,7 +7,7 @@ namespace GigeVision.Core
         /// <summary>
         /// The event that is fired when any child property changes its value
         /// </summary>
-        public event PropertyChangedEventHandler PropertyChanged = (sender, e) => { };
+        public event PropertyChangedEventHandler PropertyChanged = (_, e) => { };
 
         #region Public Methods
 

--- a/GigeVision.Core/GigeVision.Core.csproj
+++ b/GigeVision.Core/GigeVision.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Authors>Touseef Elahi</Authors>
     <Company>Stira.sa</Company>
     <Product>GigeVision</Product>
@@ -45,7 +45,6 @@
 
   <ItemGroup>
     <PackageReference Include="GenICam" Version="2.1.5.1" />
-    <PackageReference Include="Stira.WpfCore" Version="1.2.2" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
 

--- a/GigeVision.Core/GigeVision.Core.csproj
+++ b/GigeVision.Core/GigeVision.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <Authors>Touseef Elahi</Authors>
     <Company>Stira.sa</Company>
     <Product>GigeVision</Product>

--- a/GigeVision.Core/Models/CameraInformation.cs
+++ b/GigeVision.Core/Models/CameraInformation.cs
@@ -1,11 +1,11 @@
 ﻿using GigeVision.Core.Enums;
-using Stira.WpfCore;
 
 namespace GigeVision.Core.Models
 {
     /// <summary>
     /// Discovery Packet Information for GigeCamera
     /// </summary>
+    
     public class CameraInformation : BaseNotifyPropertyChanged
     {
         private string iP, networkIP;

--- a/GigeVision.Core/Services/Camera.cs
+++ b/GigeVision.Core/Services/Camera.cs
@@ -1,6 +1,5 @@
 ﻿using GigeVision.Core.Enums;
 using GigeVision.Core.Interfaces;
-using Stira.WpfCore;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/GigeVision.Core/Services/OtherServices/MotorControl.cs
+++ b/GigeVision.Core/Services/OtherServices/MotorControl.cs
@@ -1,6 +1,5 @@
 ﻿using GigeVision.Core.Enums;
 using GigeVision.Core.Interfaces;
-using Stira.WpfCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/GigeVision.Core/Services/StreamReceiverBase.cs
+++ b/GigeVision.Core/Services/StreamReceiverBase.cs
@@ -1,5 +1,4 @@
 ﻿using GigeVision.Core.Enums;
-using Stira.WpfCore;
 using System;
 using System.Net;
 using System.Net.Sockets;


### PR DESCRIPTION
Having the library agnostic, it is better to don't have any direct reference to Stira.WPF even because this dependency is only for the implementation of PropertyChanged interface.
The interface has been included directly in GigeVision.Core project. 