### PR TITLE
Traversing Firewalls or Network Address Translation Devices

### DIFF
--- a/GigeVision.Core/Enums/GevRegisters.cs
+++ b/GigeVision.Core/Enums/GevRegisters.cs
@@ -20,6 +20,7 @@
         CurrentIPAddress = 0x0024,
         CurrentSubnetMask = 0x0034,
         CurrentDefaultGateway = 0x0044,
+        GevSCSP  = 0x01C,
         FirstURL = 0x0200,
         SecondURL = 0x0400,
         NumberOfInterfaces = 0x0600,

--- a/GigeVision.Core/Interfaces/IStreamReceiver.cs
+++ b/GigeVision.Core/Interfaces/IStreamReceiver.cs
@@ -12,6 +12,16 @@ namespace GigeVision.Core.Interfaces
         /// Event for frame ready
         /// </summary>
         EventHandler<byte[]> FrameReady { get; set; }
+        
+        /// <summary>
+        /// The camera source traffic port. Required for firewall traversal traffic
+        /// </summary>
+        int CameraSourcePort { get; set; }
+        
+        /// <summary>
+        /// Camera ip, required for firewall traversal traffic
+        /// </summary>
+        string CameraIP { get; set; }
 
         /// <summary>
         /// GVSP info for image info

--- a/GigeVision.Core/Services/StreamReceiverBase.cs
+++ b/GigeVision.Core/Services/StreamReceiverBase.cs
@@ -40,6 +40,16 @@ namespace GigeVision.Core.Services
         /// GVSP info for image info
         /// </summary>
         public GvspInfo GvspInfo { get; protected set; }
+        
+        /// <summary>
+        /// The interval for sending to the camera a package to keep the route opened through the firewall
+        /// </summary>
+        public string CameraIP { get; set; }
+        
+        /// <summary>
+        /// The camera source traffic port. Required for firewall traversal traffic
+        /// </summary>
+        public int CameraSourcePort { get; set; }
 
         /// <summary>
         /// Is multicast enabled
@@ -242,12 +252,15 @@ namespace GigeVision.Core.Services
                 }
                 socketRxRaw = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                 socketRxRaw.Bind(new IPEndPoint(IPAddress.Any, PortRx));
+                socketRxRaw.ReceiveTimeout = ReceiveTimeoutInMilliseconds;
+                
+                socketRxRaw.SendTo(new byte[8], new IPEndPoint(IPAddress.Parse(CameraIP), CameraSourcePort));
+                
                 if (IsMulticast)
                 {
                     MulticastOption mcastOption = new(IPAddress.Parse(MulticastIP), IPAddress.Parse(RxIP));
                     socketRxRaw.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, mcastOption);
                 }
-                socketRxRaw.ReceiveTimeout = ReceiveTimeoutInMilliseconds;
                 //One full hd image with GVSP2.0 Header as default, it will be updated for image type
                 socketRxRaw.ReceiveBufferSize = (int)(1920 * 1100);
             }


### PR DESCRIPTION
From GigEVision Standard 2.0.03:
11.9 Traversing Firewalls or Network Address Translation Devices
Due to the unidirectional nature of GVSP traffic, it is common for the streaming channel data to be blocked
by firewalls or other types of network since the incoming traffic cannot be matched against an outgoing
packet. To address this, the SCSPx registers are designed to allow the application associated to a GVSP
receiver to create a simulated bidirectional traffic conversation between the GVSP receiver and the GVSP
transmitter streaming channel by informing the application of the remote UDP port. This information would
otherwise be unknown until the first streaming packet arrives, which may never happen if it was blocked.
Additionally, this information may be used in other ways to help configure software and/or networking
equipment.
The GVSP Capability register (at address 0x092C) can be used to query if SCSPx registers are supported
by this device.
[CR-094st] If a product supports SCSPx for one GVSP transmitter, then it MUST support it for all
its GVCP transmitter stream channels. [CR10-8st]
The suggested usage of SCSPx is to query it after opening the image stream via SCDAx and SCPx but
before starting the camera’s flow of image data. If desired, the application can query it earlier and cache it
off (only if it is non-zero) so that it does not need to query it each time the streaming channel is opened.
Refer to [CR-089cd] for proper behavior of SCSPx.
Next, the application can send a UDP packet from the same source port it programmed into SCPx to the
port specified by SCSPx. The content of this packet is ignored, but the suggested payload should be smaller
than the maximum size of a GVCP command packet. This operation should be realized on all the open
stream channels.
GigE Vision®
Specification
version 2.0
V2.0.03 April 16, 2013 Page 92 of 427
At this point the application can continue starting the acquisition on the camera. Depending on the
configuration of the firewall or other impediment, the application may choose to continue periodically
sending packets similar to the first one for the duration of the streaming session. The suggested interval is
30 seconds and could be configurable. Different firewalls might require adjustment to this interval.
[CR-095ca] When SCSPx is supported by the application, the application MUST not send packets to
the port specified by SCSPx unless it has the stream channel opened and successfully
reads a non-zero value back from SCSPx. [CR10-9ca]
The application should not expect the device to answer the packet it sends to the GVSP transmitter stream
channel. But this mechanism provides a way to open-up the UDP port in the firewall. The implementation is
left as a quality of implementation and is likely to vary with different firewall types and operating systems.
Note that the same mechanism is also available for the message channel.