### PR TITLE
If enum paramter value is a registry the parser is not working fine

### DIFF
--- a/GenICam/Services/XmlHelper.cs
+++ b/GenICam/Services/XmlHelper.cs
@@ -517,8 +517,16 @@ namespace GenICam
                     ////            isImplementedValue = await GetGenCategory(isImplementedExpr);
                     ////    }
                     ////}
-                    uint entryValue;
-                    uint.TryParse(SelectSingleNode(enumEntry, NodeValue).InnerText, out entryValue);
+                    long entryValue = 0;
+                    if (SelectSingleNode(enumEntry, NodeValue).InnerText.StartsWith("0x"))
+                    {
+                        entryValue = long.Parse(SelectSingleNode(enumEntry, NodeValue).InnerText.Replace("0x", String.Empty), System.Globalization.NumberStyles.HexNumber);
+                    }
+                    else
+                    {
+                        long.TryParse(SelectSingleNode(enumEntry, NodeValue).InnerText, out entryValue);
+                    }
+
                     entry.Add(enumEntry.Attributes[NodeName].Value, new EnumEntry(entryValue, isImplementedValue));
                 }
 

--- a/GigeVision.Core/Services/Camera.cs
+++ b/GigeVision.Core/Services/Camera.cs
@@ -576,12 +576,13 @@ namespace GigeVision.Core.Services
             {
                 cameraParametersCache = new Dictionary<string, ICategory>();
             }
-            if (!cameraParametersCache.ContainsKey(parameterName) && ! await LoadParameter(parameterName))
+            ICategory parameter = await GetParameter(parameterName).ConfigureAwait(false);
+            if (parameter == null)
             {
                 return null;
             }
            
-            return await cameraParametersCache[parameterName].PValue.GetValueAsync().ConfigureAwait(false);
+            return await parameter.PValue.GetValueAsync().ConfigureAwait(false);
         }
         
         /// <summary>
@@ -608,12 +609,13 @@ namespace GigeVision.Core.Services
         /// <returns></returns>
         public async Task<CategoryProperties> GetParameterProperties(string parameterName)
         {
-            if (!cameraParametersCache.ContainsKey(parameterName) && ! await LoadParameter(parameterName).ConfigureAwait(false))
+            ICategory parameter = await GetParameter(parameterName).ConfigureAwait(false);
+            if (parameter == null)
             {
                 return null;
             }
 
-            return cameraParametersCache[parameterName].CategoryProperties;
+            return parameter.CategoryProperties;
         }
         
         /// <summary>
@@ -623,39 +625,58 @@ namespace GigeVision.Core.Services
         /// <returns></returns>
         public async Task<long> GetParameterMinValue(string parameterName)
         {
-            if (!cameraParametersCache.ContainsKey(parameterName) && ! await LoadParameter(parameterName).ConfigureAwait(false))
+            ICategory parameter = await GetParameter(parameterName).ConfigureAwait(false);
+            
+            if (parameter == null)
             {
                 return 0;
             }
 
-            if (cameraParametersCache[parameterName].PMin == null)
+            if (parameter.PMin == null)
             {
                 return 0;
             }
             
-            var result = await cameraParametersCache[parameterName].PMin.GetValueAsync().ConfigureAwait(false);
+            var result = await parameter.PMin.GetValueAsync().ConfigureAwait(false);
             return result ?? 0;
         }
         
         /// <summary>
         /// Obtain the maximum value allowed for the parameter. 0 if the parameter does not support it.
         /// </summary>
-        /// <param name="parameterName">The name of the parameter&lt;</param>;
+        /// <param name="parameterName">The name of the parameter</param>;
         /// <returns></returns>
         public async Task<long> GetParameterMaxValue(string parameterName)
         {
-            if (!cameraParametersCache.ContainsKey(parameterName) && ! await LoadParameter(parameterName).ConfigureAwait(false))
+            ICategory parameter = await GetParameter(parameterName).ConfigureAwait(false);
+            
+            if (parameter == null)
             {
                 return 0;
             }
 
-            if (cameraParametersCache[parameterName].PMax == null)
+            if (parameter.PMax == null)
             {
                 return 0;
             }
             
-            var result = await cameraParametersCache[parameterName].PMax.GetValueAsync().ConfigureAwait(false);
+            var result = await parameter.PMax.GetValueAsync().ConfigureAwait(false);
             return result ?? 0;
+        }
+        
+        /// <summary>
+        /// Get the description of the parameter
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter</param>
+        /// <returns></returns>
+        public async Task<ICategory> GetParameter(string parameterName)
+        {
+            if (!cameraParametersCache.ContainsKey(parameterName) && ! await LoadParameter(parameterName).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            return cameraParametersCache[parameterName];
         }
 
         /// <summary>


### PR DESCRIPTION
If the enum parameter of a category is a registry value (starting with 0x) the int parser was not working fine. Now we support both, registry and values