### PR TITLE
Keeping sent a package during the stream for firewall hole punching

### DIFF
--- a/GenICam/Services/XmlHelper.cs
+++ b/GenICam/Services/XmlHelper.cs
@@ -423,9 +423,12 @@ namespace GenICam
                                 else if (pNode.Attributes["Name"].Value.EndsWith("_Float") || pNode.Attributes["Name"].Value.EndsWith("_Int") || pNode.Attributes["Name"].Value.EndsWith("_Bit"))
                                 {
                                     var register = await GetRegisterByName(pNode.Attributes["Name"].Value).ConfigureAwait(false);
-                                    pValue = register.PValue;
-                                    pMin = register.PMin;
-                                    pMax = register.PMax;
+                                    if (register != null)
+                                    {
+                                        pValue = register.PValue;
+                                        pMin = register.PMin;
+                                        pMax = register.PMax;
+                                    }
                                 }
                             }
 
@@ -477,7 +480,10 @@ namespace GenICam
                         else if (pNode.Attributes["Name"].Value.EndsWith("_Float") || pNode.Attributes["Name"].Value.EndsWith("_Int") || pNode.Attributes["Name"].Value.EndsWith("_Bit"))
                         {
                             var register = await GetRegisterByName(pNode.Attributes["Name"].Value).ConfigureAwait(false);
-                            pValue = register.PValue;
+                            if (register != null)
+                            {
+                                pValue = register.PValue;   
+                            }
                         }
                     }
                 }
@@ -549,7 +555,10 @@ namespace GenICam
                         else if (pNode.Attributes["Name"].Value.EndsWith("_Float") || pNode.Attributes["Name"].Value.EndsWith("_Int") || pNode.Attributes["Name"].Value.EndsWith("_Bit"))
                         {
                             var register = await GetRegisterByName(pNode.Attributes["Name"].Value).ConfigureAwait(false);
-                            pValue = register.PValue;
+                            if (register != null)
+                            {
+                                pValue = register.PValue;
+                            }
                         }
                     }
                 }
@@ -734,7 +743,10 @@ namespace GenICam
                 else if (pNode.Attributes["Name"].Value.EndsWith("_Float") || pNode.Attributes["Name"].Value.EndsWith("_Int") || pNode.Attributes["Name"].Value.EndsWith("_Bit"))
                 {
                     var register = await GetRegisterByName(pNode.Attributes["Name"].Value).ConfigureAwait(false);
-                    pValue = register.PValue;
+                    if (register != null)
+                    {
+                        pValue = register.PValue;
+                    }
                 }
             }
 
@@ -772,7 +784,10 @@ namespace GenICam
                     else if (pNode.Attributes["Name"].Value.EndsWith("_Float") || pNode.Attributes["Name"].Value.EndsWith("_Int") || pNode.Attributes["Name"].Value.EndsWith("_Bit"))
                     {
                         var register = await GetRegisterByName(pNode.Attributes["Name"].Value).ConfigureAwait(false);
-                        pValue = register.PValue;
+                        if (register != null)
+                        {
+                            pValue = register.PValue;   
+                        }
                     }
                 }
 
@@ -977,7 +992,10 @@ namespace GenICam
                                 else if (pNode.Attributes["Name"].Value.EndsWith("_Float") || pNode.Attributes["Name"].Value.EndsWith("_Int") || pNode.Attributes["Name"].Value.EndsWith("_Bit"))
                                 {
                                     var register = await GetRegisterByName(pNode.Attributes["Name"].Value).ConfigureAwait(false);
-                                    pValue = register.PValue;
+                                    if (register != null)
+                                    {
+                                        pValue = register.PValue;   
+                                    }
                                 }
                             }
 

--- a/GigeVision.Core/Interfaces/IStreamReceiver.cs
+++ b/GigeVision.Core/Interfaces/IStreamReceiver.cs
@@ -67,6 +67,11 @@ namespace GigeVision.Core.Interfaces
         /// General update event
         /// </summary>
         EventHandler<string> Updates { get; set; }
+        
+        /// <summary>
+        /// Time interval from a package to another for firewall traversal. Set value <= 0 to disable it
+        /// </summary>
+        public int FirewallPunchKeepAliveIntervalInSeconds { get; set; }
 
         /// <summary>
         /// Start reception thread


### PR DESCRIPTION
I added the keep alive hole punching (default 30 seconds). It is not possible to create a dedicated thread for this operation because the socket is bound in Receiver() method and it might collide with the blocking Receive operation. I added a check in the receiver loop. If the time between the last keep alive and the current time is >= with the defined timeout (30 seconds as default) a package is sent.